### PR TITLE
Ajout du module Cahier des charges / Nouveau concept

### DIFF
--- a/aircraft_designer/doc_dev/dev_log.md
+++ b/aircraft_designer/doc_dev/dev_log.md
@@ -1,3 +1,4 @@
 # Journal de développement
 
 - 2025-09-08 : Mise en place du cœur du logiciel (gestion de projet, chargement de modules, interface PyQt5).
+- 2025-09-09 : Module Cahier des charges / Nouveau concept — UI avec 2 onglets, bouton convertir, persistance JSON, intégration navigation, test de sauvegarde/chargement.

--- a/aircraft_designer/doc_dev/todo.md
+++ b/aircraft_designer/doc_dev/todo.md
@@ -1,4 +1,12 @@
 # Liste des tâches
 
+## À faire
 - [ ] Ajouter des modules fonctionnels dans /modules/
 - [ ] Améliorer la gestion des métadonnées des projets
+- [ ] Export PDF/Excel du cahier des charges
+- [ ] Cartouches métadonnées (auteur, version, statut)
+- [ ] Historique versions (diff JSON)
+- [ ] Liens avec module « Technologies à utiliser »
+
+## Terminée
+- [2025-09-09] Créer le module `cahier_des_charges` avec ses deux sous-parties

--- a/aircraft_designer/gui/main_window.py
+++ b/aircraft_designer/gui/main_window.py
@@ -1,6 +1,7 @@
 from PyQt5.QtWidgets import QMainWindow, QTabWidget
 
 from ..core.module_loader import load_modules
+from ..modules.cahier_des_charges.widget import CahierDesChargesWidget
 
 
 class MainWindow(QMainWindow):
@@ -14,7 +15,18 @@ class MainWindow(QMainWindow):
         self.tabs = QTabWidget()
         self.setCentralWidget(self.tabs)
 
-        self.modules = load_modules(project)
-        for module in self.modules:
+        self.modules = []
+        for module in load_modules(project):
             widget = module.get_widget()
-            self.tabs.addTab(widget, module.__class__.__name__)
+            if hasattr(widget, "load_from_project"):
+                widget.load_from_project(project.path)
+            self.tabs.addTab(
+                widget,
+                getattr(widget, "module_name", module.__class__.__name__),
+            )
+            self.modules.append(widget)
+
+        cahier_widget = CahierDesChargesWidget()
+        cahier_widget.load_from_project(project.path)
+        self.tabs.addTab(cahier_widget, cahier_widget.module_name)
+        self.modules.append(cahier_widget)

--- a/aircraft_designer/modules/cahier_des_charges/__init__.py
+++ b/aircraft_designer/modules/cahier_des_charges/__init__.py
@@ -1,0 +1,3 @@
+"""Module Cahier des charges / Nouveau concept."""
+
+# Les classes sont importées explicitement dans les modules consommateurs.

--- a/aircraft_designer/modules/cahier_des_charges/_smoke_test.py
+++ b/aircraft_designer/modules/cahier_des_charges/_smoke_test.py
@@ -1,0 +1,33 @@
+"""Test rapide de sauvegarde/chargement du cahier des charges."""
+
+from pathlib import Path
+import shutil
+import sys
+
+ROOT_DIR = Path(__file__).resolve().parents[3]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from aircraft_designer.modules.cahier_des_charges.model import (
+    CahierDesChargesModel,
+)
+from aircraft_designer.modules.cahier_des_charges.storage import (
+    load_cahier_des_charges,
+    save_cahier_des_charges,
+)
+
+
+def main() -> None:
+    project_dir = Path(__file__).resolve().parent / "__test_project__"
+    project_dir.mkdir(exist_ok=True)
+    model = CahierDesChargesModel()
+    model.classique.mission = "Test"
+    save_cahier_des_charges(project_dir, model)
+    loaded = load_cahier_des_charges(project_dir)
+    assert loaded.classique.mission == "Test"
+    print("Smoke test OK")
+    shutil.rmtree(project_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/aircraft_designer/modules/cahier_des_charges/model.py
+++ b/aircraft_designer/modules/cahier_des_charges/model.py
@@ -1,0 +1,66 @@
+"""Structures de données pour le module Cahier des charges."""
+
+from dataclasses import dataclass, field, asdict
+from typing import Dict
+
+
+@dataclass
+class CahierClassique:
+    """Section classique du cahier des charges."""
+
+    mission: str = ""
+    performances: str = ""
+    handling: str = ""
+    manufacturing: str = ""
+    certifiability: str = ""
+    upgradability: str = ""
+    maintainability: str = ""
+    accessibility: str = ""
+    aesthetic: str = ""
+    client: str = ""
+
+
+@dataclass
+class CahierConcept:
+    """Section nouveau concept du cahier des charges."""
+
+    inspiration: str = ""
+    public_cible: str = ""
+    innovations: str = ""
+    contraintes: str = ""
+    fonctionnalites_cles: str = ""
+    croquis_ou_notes: str = ""
+
+
+@dataclass
+class CahierDesChargesModel:
+    """Modèle principal du cahier des charges."""
+
+    version: str = "1.0"
+    last_modified_utc: str = ""
+    mode: str = "classique"
+    classique: CahierClassique = field(default_factory=CahierClassique)
+    concept: CahierConcept = field(default_factory=CahierConcept)
+
+    def to_dict(self) -> Dict[str, Dict[str, str] | str]:
+        """Convertit le modèle en dictionnaire."""
+        return {
+            "version": self.version,
+            "last_modified_utc": self.last_modified_utc,
+            "mode": self.mode,
+            "classique": asdict(self.classique),
+            "concept": asdict(self.concept),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Dict[str, str] | str]) -> "CahierDesChargesModel":
+        """Crée une instance à partir d'un dictionnaire."""
+        classique = CahierClassique(**data.get("classique", {}))
+        concept = CahierConcept(**data.get("concept", {}))
+        return cls(
+            version=data.get("version", "1.0"),
+            last_modified_utc=data.get("last_modified_utc", ""),
+            mode=data.get("mode", "classique"),
+            classique=classique,
+            concept=concept,
+        )

--- a/aircraft_designer/modules/cahier_des_charges/storage.py
+++ b/aircraft_designer/modules/cahier_des_charges/storage.py
@@ -1,0 +1,36 @@
+"""Gestion de la persistance pour le module Cahier des charges."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+from .model import CahierDesChargesModel
+from .validators import sanitize_loaded_dict, trim_model
+
+FILE_NAME = "cahier_des_charges.json"
+
+
+def load_cahier_des_charges(project_path: Path) -> CahierDesChargesModel:
+    """Charge les données du projet."""
+    file_path = project_path / FILE_NAME
+    if not file_path.is_file():
+        return CahierDesChargesModel()
+    with open(file_path, "r", encoding="utf-8") as handle:
+        data = json.load(handle)
+    data = sanitize_loaded_dict(data)
+    return CahierDesChargesModel.from_dict(data)
+
+
+def save_cahier_des_charges(project_path: Path, model: CahierDesChargesModel) -> CahierDesChargesModel:
+    """Sauvegarde les données du module de manière atomique."""
+    trim_model(model)
+    model.last_modified_utc = datetime.utcnow().isoformat() + "Z"
+    data = model.to_dict()
+    file_path = project_path / FILE_NAME
+    tmp_path = file_path.with_suffix(".tmp")
+    with open(tmp_path, "w", encoding="utf-8") as handle:
+        json.dump(data, handle, ensure_ascii=False, indent=2)
+    tmp_path.replace(file_path)
+    return model

--- a/aircraft_designer/modules/cahier_des_charges/validators.py
+++ b/aircraft_designer/modules/cahier_des_charges/validators.py
@@ -1,0 +1,38 @@
+"""Fonctions de validation et de nettoyage."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from .model import CahierDesChargesModel
+
+
+DEFAULT_DICT = CahierDesChargesModel().to_dict()
+
+
+def _clean_str(value: Any) -> str:
+    return str(value).strip()
+
+
+def sanitize_loaded_dict(data: Dict[str, Any]) -> Dict[str, Any]:
+    """S'assure que la structure des données correspond au modèle."""
+    def recursive(default: Dict[str, Any], current: Dict[str, Any]) -> Dict[str, Any]:
+        result: Dict[str, Any] = {}
+        for key, default_value in default.items():
+            if isinstance(default_value, dict):
+                current_value = current.get(key, {}) if isinstance(current.get(key), dict) else {}
+                result[key] = recursive(default_value, current_value)
+            else:
+                result[key] = _clean_str(current.get(key, default_value))
+        return result
+
+    return recursive(DEFAULT_DICT, data or {})
+
+
+def trim_model(model: CahierDesChargesModel) -> None:
+    """Supprime les espaces inutiles dans le modèle."""
+    for key, value in model.classique.__dict__.items():
+        setattr(model.classique, key, _clean_str(value))
+    for key, value in model.concept.__dict__.items():
+        setattr(model.concept, key, _clean_str(value))
+    model.mode = model.mode.strip() or "classique"

--- a/aircraft_designer/modules/cahier_des_charges/widget.py
+++ b/aircraft_designer/modules/cahier_des_charges/widget.py
@@ -1,0 +1,196 @@
+"""Interface utilisateur pour le module Cahier des charges."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import Dict
+
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import (
+    QAction,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QPlainTextEdit,
+    QScrollArea,
+    QTabWidget,
+    QToolBar,
+    QVBoxLayout,
+    QWidget,
+)
+
+from .model import CahierDesChargesModel
+from .storage import load_cahier_des_charges, save_cahier_des_charges
+
+CLASSIC_FIELDS: Dict[str, str] = {
+    "mission": "Définition de la mission",
+    "performances": "Performances requises",
+    "handling": "Handling",
+    "manufacturing": "Ease of manufacturing",
+    "certifiability": "Certifiability",
+    "upgradability": "Upgradability",
+    "maintainability": "Maintainability",
+    "accessibility": "Accessibility",
+    "aesthetic": "Aesthetic",
+    "client": "Client",
+}
+
+CONCEPT_FIELDS: Dict[str, str] = {
+    "inspiration": "Inspiration / Intention",
+    "public_cible": "Public cible / Scénario d’usage",
+    "innovations": "Vision de rupture ou innovations",
+    "contraintes": "Contraintes auto-imposées",
+    "fonctionnalites_cles": "Fonctionnalités clés souhaitées",
+    "croquis_ou_notes": "Croquis ou notes libres",
+}
+
+CONCEPT_TO_CLASSIC: Dict[str, str] = {
+    "inspiration": "mission",
+    "public_cible": "client",
+    "innovations": "performances",
+    "contraintes": "handling",
+    "fonctionnalites_cles": "manufacturing",
+    "croquis_ou_notes": "aesthetic",
+}
+
+
+class CahierDesChargesWidget(QWidget):
+    """Widget principal du module Cahier des charges."""
+
+    module_id = "cahier_des_charges"
+    module_name = "Cahier des charges / Nouveau concept"
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.project_path: Path | None = None
+        self.model = CahierDesChargesModel()
+        self.classic_edits: Dict[str, QPlainTextEdit] = {}
+        self.concept_edits: Dict[str, QPlainTextEdit] = {}
+
+        self.tabs = QTabWidget()
+        self.tabs.currentChanged.connect(self._on_tab_changed)
+        classic_tab = self._create_classic_tab()
+        concept_tab = self._create_concept_tab()
+        self.tabs.addTab(classic_tab, "Cahier classique")
+        self.tabs.addTab(concept_tab, "Nouveau concept")
+
+        self.toolbar = QToolBar()
+        self.toolbar.setMovable(False)
+        self.save_action = QAction("Sauvegarder", self)
+        self.save_action.setShortcut("Ctrl+S")
+        self.save_action.triggered.connect(self._on_save)
+        self.reload_action = QAction("Recharger", self)
+        self.reload_action.triggered.connect(self._on_reload)
+        self.convert_action = QAction("Convertir concept → classique", self)
+        self.convert_action.triggered.connect(self._convert_concept)
+        self.toolbar.addAction(self.save_action)
+        self.toolbar.addAction(self.reload_action)
+        self.toolbar.addAction(self.convert_action)
+
+        self.status_label = QLabel("Dernière sauvegarde : -")
+
+        main_layout = QVBoxLayout(self)
+        top_layout = QHBoxLayout()
+        top_layout.addStretch()
+        top_layout.addWidget(self.toolbar)
+        main_layout.addLayout(top_layout)
+        main_layout.addWidget(self.tabs)
+        main_layout.addWidget(self.status_label)
+
+    # ------------------------------------------------------------------
+    # UI creation helpers
+    def _create_classic_tab(self) -> QWidget:
+        container = QWidget()
+        layout = QVBoxLayout(container)
+        for key, label in CLASSIC_FIELDS.items():
+            group = QGroupBox(label)
+            group_layout = QVBoxLayout(group)
+            edit = QPlainTextEdit()
+            group_layout.addWidget(edit)
+            layout.addWidget(group)
+            self.classic_edits[key] = edit
+        layout.addStretch()
+
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setWidget(container)
+        return scroll
+
+    def _create_concept_tab(self) -> QWidget:
+        container = QWidget()
+        layout = QVBoxLayout(container)
+        for key, label in CONCEPT_FIELDS.items():
+            group = QGroupBox(label)
+            group_layout = QVBoxLayout(group)
+            edit = QPlainTextEdit()
+            group_layout.addWidget(edit)
+            layout.addWidget(group)
+            self.concept_edits[key] = edit
+        layout.addStretch()
+
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setWidget(container)
+        return scroll
+
+    # ------------------------------------------------------------------
+    # Project interaction
+    def load_from_project(self, project_path: Path | None) -> None:
+        self.project_path = project_path
+        if project_path is None:
+            self.model = CahierDesChargesModel()
+            self._update_ui_from_model()
+            return
+        self.model = load_cahier_des_charges(project_path)
+        self._update_ui_from_model()
+
+    def save_to_project(self, project_path: Path | None = None) -> None:
+        project_path = project_path or self.project_path
+        if project_path is None:
+            return
+        self._update_model_from_ui()
+        self.model = save_cahier_des_charges(project_path, self.model)
+        self._update_status_label()
+
+    # ------------------------------------------------------------------
+    # Event handlers
+    def _on_save(self) -> None:
+        self.save_to_project()
+
+    def _on_reload(self) -> None:
+        if self.project_path is not None:
+            self.load_from_project(self.project_path)
+
+    def _convert_concept(self) -> None:
+        for src, dst in CONCEPT_TO_CLASSIC.items():
+            self.classic_edits[dst].setPlainText(self.concept_edits[src].toPlainText())
+        self.tabs.setCurrentIndex(0)
+        self.model.mode = "classique"
+
+    def _on_tab_changed(self, index: int) -> None:
+        self.model.mode = "classique" if index == 0 else "concept"
+
+    # ------------------------------------------------------------------
+    # Helpers
+    def _update_ui_from_model(self) -> None:
+        for key, edit in self.classic_edits.items():
+            edit.setPlainText(getattr(self.model.classique, key))
+        for key, edit in self.concept_edits.items():
+            edit.setPlainText(getattr(self.model.concept, key))
+        self.tabs.setCurrentIndex(0 if self.model.mode == "classique" else 1)
+        self._update_status_label()
+
+    def _update_model_from_ui(self) -> None:
+        for key, edit in self.classic_edits.items():
+            setattr(self.model.classique, key, edit.toPlainText())
+        for key, edit in self.concept_edits.items():
+            setattr(self.model.concept, key, edit.toPlainText())
+
+    def _update_status_label(self) -> None:
+        if not self.model.last_modified_utc:
+            self.status_label.setText("Dernière sauvegarde : -")
+            return
+        dt = datetime.fromisoformat(self.model.last_modified_utc.replace("Z", "+00:00"))
+        local_dt = dt.astimezone()
+        self.status_label.setText(f"Dernière sauvegarde : {local_dt:%H:%M:%S}")


### PR DESCRIPTION
## Résumé
- Ajout d'un module "Cahier des charges / Nouveau concept" avec interface à onglets et conversion concept -> classique
- Persistance JSON par projet et gestion de rechargement/sauvegarde
- Intégration dans la fenêtre principale et mise à jour de la documentation

## Tests
- `python aircraft_designer/modules/cahier_des_charges/_smoke_test.py`


------
https://chatgpt.com/codex/tasks/task_e_68bfa8f9ff5c8320a778a8ccc6418648